### PR TITLE
improve randomness entropy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,6 +1759,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,7 +2029,10 @@ dependencies = [
 name = "ta-bot"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "rand",
+ "rand_chacha",
+ "sha2",
  "shuttle-runtime",
  "teloxide",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,10 @@ edition = "2024"
 publish = false
 
 [dependencies]
+chrono = "0.4.42"
 rand = "0.9.2"
+rand_chacha = "0.9.0"
+sha2 = "0.10.9"
 shuttle-runtime = "0.57.0"
 teloxide = { version = "0.17.0", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(iter_intersperse)]
 
+mod rng;
 pub mod dice;
 mod shuttle;
 mod telegram;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,49 @@
+use chrono::Utc;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use sha2::Digest;
+
+/// RNG picked for the triangle agency bot.
+pub type TriangleAgencyRng = ChaCha20Rng;
+
+/// Creates an RNG from giving seed feed input.
+///
+/// The input of arbitrary is used to produce a seed of the correct length.
+/// Additionally, timestamp data is appended to the seed feed input.
+pub fn create_rng(seed_feed: impl Into<Vec<u8>>) -> TriangleAgencyRng {
+    let mut seed_feed = seed_feed.into();
+    let now = Utc::now();
+    let nanos = now.timestamp_subsec_nanos();
+    let seconds = now.timestamp();
+    seed_feed.extend_from_slice(&nanos.to_le_bytes());
+    seed_feed.extend_from_slice(&seconds.to_le_bytes());
+    let mut seed_hasher = sha2::Sha256::new();
+    seed_hasher.update(seed_feed);
+    let seed = seed_hasher.finalize().into();
+    TriangleAgencyRng::from_seed(seed)
+}
+
+#[cfg(test)]
+mod test {
+    use rand::Rng;
+
+    use crate::rng::create_rng;
+
+    #[test]
+    fn rng_entropy_preserved_by_changing_input_byte() {
+        let mut rng = create_rng([1_u8]);
+        let byte0 = rng.random::<u8>();
+        let mut rng = create_rng([0_u8]);
+        let byte1 = rng.random::<u8>();
+        assert_ne!(byte0, byte1);
+    }
+
+    #[test]
+    fn rng_entropy_preserved_by_changing_input_length() {
+        let mut rng = create_rng([1_u8]);
+        let byte0 = rng.random::<u8>();
+        let mut rng = create_rng([1_u8, 2_u8]);
+        let byte1 = rng.random::<u8>();
+        assert_ne!(byte0, byte1);
+    }
+}

--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -3,17 +3,25 @@ use teloxide::{
     dispatching::UpdateHandler,
     prelude::*,
     types::{
-        InlineQueryResult, InlineQueryResultArticle, InputMessageContent, InputMessageContentText,
+        InlineQueryResult,
+        InlineQueryResultArticle,
+        InputMessageContent,
+        InputMessageContentText,
     },
 };
 
+use crate::rng::create_rng;
+
 async fn inline_query_handler(bot: Bot, q: InlineQuery) -> ResponseResult<()> {
-    let outcome = crate::dice::roll();
+    let mut rng = create_rng(q.id.to_string());
+    let outcome = crate::dice::roll(&mut rng);
 
     let result = InlineQueryResultArticle::new(
         "roll_6d4",
         "🎲 Roll 6d4",
-        InputMessageContent::Text(InputMessageContentText::new(outcome.to_string())),
+        InputMessageContent::Text(InputMessageContentText::new(
+            outcome.to_string(),
+        )),
     )
     .description(format!("Roll to alter reality"));
 


### PR DESCRIPTION
This PR is dedicated to improve randomness entropy, as it looks like the deployed OS entropy is not good enough, very low-quality. Repeated calls tend to yield the same result.

I improve the randomness by explicitly constructing an RNG from some input data.
What input data am I using? Telegram's query ID.

I am also:

1. Using a more good quality PRNG, in fact, a CSPRNG (ChaCha20)
2. "Spicying up" the RNG's seed with timestamp data, just to be sure. This is more like a bonus, is it really needed(?)

PS: I couldn't test the actual bot deployed, but it should work.

EDIT: added missing info